### PR TITLE
set short_open_tags to on

### DIFF
--- a/php-generate-autoload
+++ b/php-generate-autoload
@@ -1,4 +1,4 @@
-#!/usr/bin/env php
+#!/usr/bin/php -dshort_open_tag=1
 <?php
 
 if (\file_exists(__DIR__ . '/vendor/autoload.php')) {


### PR DESCRIPTION
in our codebase we need short_open_tags to be on. users' desktops can't be guaranteed to have the ini file turned on, so it's convenient to do it in the script